### PR TITLE
Add affiliate leaderboard page and App Store Connect query

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import MessageCenter from "./modules/messageCenter";
 import Message from "./modules/Message";
 import AdminPage from "./modules/admin";
 import SpeedDatePage from "./modules/speedDate";
+import LeaderboardPage from "./modules/leaderboard";
 import { Map } from "./components";
 
 import "./App.css";
@@ -29,6 +30,7 @@ class App extends React.PureComponent {
           <Route path="/message" component={Message} />
           <ProtectedRoute path="/grid-search" component={GridSearch} />
           <Route path="/speed-date" component={SpeedDatePage} />
+          <Route exact path="/leaderboard" component={LeaderboardPage} />
           <ProtectedRoute exact path="/admin" component={AdminPage} />
         </Switch>
       </Fragment>

--- a/client/src/graphql/queries.jsx
+++ b/client/src/graphql/queries.jsx
@@ -584,3 +584,16 @@ export const GET_REAL_USERS = gql`
     }
   }
 `;
+
+export const GET_AFFILIATE_DOWNLOADS = gql`
+  query GetAffiliateDownloads($reportDate: String) {
+    getAffiliateDownloads(reportDate: $reportDate) {
+      reportDate
+      goal
+      affiliates {
+        affiliateName
+        downloads
+      }
+    }
+  }
+`;

--- a/client/src/modules/leaderboard/Leaderboard.jsx
+++ b/client/src/modules/leaderboard/Leaderboard.jsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Loading,
+  ProgressBar,
+  Text,
+  FONT_SIZES,
+} from "../../components";
+import { useClient } from "../../client";
+import { GET_AFFILIATE_DOWNLOADS } from "../../graphql/queries";
+import { COLORS } from "../../constants";
+
+const Leaderboard = () => {
+  const client = useClient();
+  const [leaderboard, setLeaderboard] = useState({
+    affiliates: [],
+    goal: 1000,
+    reportDate: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchLeaderboard = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await client.request(GET_AFFILIATE_DOWNLOADS);
+      if (response && response.getAffiliateDownloads) {
+        setLeaderboard(response.getAffiliateDownloads);
+      } else {
+        setLeaderboard({ affiliates: [], goal: 1000, reportDate: "" });
+      }
+    } catch (err) {
+      console.error("Error loading affiliate downloads:", err);
+      setError(
+        "We couldn't load the latest affiliate downloads. Please try again."
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLeaderboard();
+  }, []);
+
+  const goal = useMemo(() => {
+    const parsedGoal = Number(leaderboard.goal);
+    if (!Number.isFinite(parsedGoal) || parsedGoal <= 0) {
+      return 1000;
+    }
+
+    return parsedGoal;
+  }, [leaderboard.goal]);
+
+  const affiliates = useMemo(() => {
+    if (!leaderboard.affiliates) {
+      return [];
+    }
+
+    return [...leaderboard.affiliates].sort(
+      (first, second) => second.downloads - first.downloads
+    );
+  }, [leaderboard.affiliates]);
+
+  let formattedReportDate = null;
+  if (leaderboard.reportDate) {
+    const date = new Date(`${leaderboard.reportDate}T00:00:00Z`);
+    if (!Number.isNaN(date.getTime())) {
+      formattedReportDate = date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+    }
+  }
+
+  return (
+    <Box
+      width="100%"
+      justifyContent="center"
+      alignItems="center"
+      backgroundColor={COLORS.black}
+      paddingX={16}
+      paddingY={32}
+      style={{ minHeight: "calc(100vh - 60px)" }}
+    >
+      <Box
+        column
+        width="100%"
+        maxWidth={960}
+        backgroundColor={COLORS.darkestGrey}
+        borderRadius={16}
+        padding={24}
+        boxShadow="0 12px 32px rgba(0, 0, 0, 0.45)"
+      >
+        <Text
+          fontSize={FONT_SIZES.XX_LARGE}
+          bold
+          color={COLORS.white}
+          marginBottom="8px"
+        >
+          Affiliate Leaderboard
+        </Text>
+        <Text color={COLORS.lightGrey} marginBottom="24px">
+          App Store Connect data updates once per day and typically arrives
+          with about a two day delay.
+        </Text>
+        {formattedReportDate && (
+          <Text color={COLORS.lightBlue} marginBottom="16px" bold>
+            Latest report: {formattedReportDate}
+          </Text>
+        )}
+
+        <Box alignItems="center" marginBottom="16px">
+          <Button
+            type="button"
+            width="auto"
+            padding="8px 16px"
+            color={COLORS.vividBlue}
+            onClick={fetchLeaderboard}
+            disabled={loading}
+          >
+            Refresh
+          </Button>
+        </Box>
+
+        {loading ? (
+          <Loading ring size={48} />
+        ) : error ? (
+          <Box column alignItems="flex-start">
+            <Text color={COLORS.red} marginBottom="8px">
+              {error}
+            </Text>
+            <Text color={COLORS.lightGrey}>
+              If the issue continues, double-check the App Store Connect
+              credentials and try again later.
+            </Text>
+          </Box>
+        ) : affiliates.length ? (
+          <Box column width="100%">
+            {affiliates.map((affiliate, index) => {
+              const downloads = Number(affiliate.downloads) || 0;
+              return (
+                <Box
+                  key={`${affiliate.affiliateName}-${index}`}
+                  column
+                  card
+                  width="100%"
+                  backgroundColor={COLORS.darkGrey}
+                  marginBottom="16px"
+                  padding={16}
+                >
+                  <Box
+                    width="100%"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    flexWrap="wrap"
+                  >
+                    <Text
+                      color={COLORS.white}
+                      bold
+                      fontSize={FONT_SIZES.LARGE}
+                      margin={0}
+                    >
+                      {`${index + 1}. ${affiliate.affiliateName}`}
+                    </Text>
+                    <Text
+                      color={COLORS.lightBlue}
+                      fontSize={FONT_SIZES.LARGE}
+                      margin={0}
+                      noWrap
+                    >
+                      {downloads.toLocaleString()} downloads
+                    </Text>
+                  </Box>
+                  <Box width="100%" marginTop="12px" justifyContent="flex-start">
+                    <ProgressBar
+                      completed={Math.min(downloads, goal)}
+                      total={goal}
+                    />
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        ) : (
+          <Box column>
+            <Text color={COLORS.white} marginBottom="8px">
+              We couldn't find any affiliate downloads for the latest report
+              yet.
+            </Text>
+            <Text color={COLORS.lightGrey}>
+              Check back soon—App Store Connect can take a couple of days to
+              release new numbers.
+            </Text>
+          </Box>
+        )}
+
+        <Text color={COLORS.lightGrey} marginTop="24px">
+          Each progress bar tracks progress toward {goal.toLocaleString()} total
+          downloads.
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default Leaderboard;

--- a/client/src/modules/leaderboard/index.jsx
+++ b/client/src/modules/leaderboard/index.jsx
@@ -1,0 +1,1 @@
+export { default } from "./Leaderboard";

--- a/graphQL/index.js
+++ b/graphQL/index.js
@@ -28,6 +28,7 @@ const {
   getFlaggedVideosResolver,
   getRealUsersResolver,
   isLikedResolver,
+  getAffiliateDownloadsResolver,
 } = require("./queries");
 const {
   createRoomResolver,
@@ -115,6 +116,7 @@ const resolvers = {
     getFlaggedVideos: getFlaggedVideosResolver,
     getRealUsers: getRealUsersResolver,
     isLiked: isLikedResolver,
+    getAffiliateDownloads: getAffiliateDownloadsResolver,
   },
   Mutation: {
     createRoom: createRoomResolver,

--- a/graphQL/queries/getAffiliateDownloads.js
+++ b/graphQL/queries/getAffiliateDownloads.js
@@ -1,0 +1,19 @@
+const { ApolloError } = require("apollo-server");
+const { fetchAffiliateDownloads } = require("../../utils/appStoreConnect");
+
+module.exports = {
+  getAffiliateDownloadsResolver: async (_, args) => {
+    try {
+      const data = await fetchAffiliateDownloads({
+        reportDate: args && args.reportDate,
+      });
+      return data;
+    } catch (error) {
+      console.error(
+        "Failed to fetch affiliate downloads from App Store Connect:",
+        error
+      );
+      throw new ApolloError(error.message);
+    }
+  },
+};

--- a/graphQL/queries/index.js
+++ b/graphQL/queries/index.js
@@ -14,6 +14,7 @@ const {
 } = require("./getFlagged");
 const { getRealUsersResolver } = require("./getRealUsers");
 const { isLikedResolver } = require("./isLiked");
+const { getAffiliateDownloadsResolver } = require("./getAffiliateDownloads");
 
 module.exports = {
   fetchMeResolver,
@@ -30,4 +31,5 @@ module.exports = {
   getFlaggedVideosResolver,
   getRealUsersResolver,
   isLikedResolver,
+  getAffiliateDownloadsResolver,
 };

--- a/graphQL/rootDefs.js
+++ b/graphQL/rootDefs.js
@@ -244,6 +244,17 @@ module.exports = gql`
     uid: String!
   }
 
+  type AffiliateDownload {
+    affiliateName: String!
+    downloads: Int!
+  }
+
+  type AffiliateLeaderboard {
+    reportDate: String!
+    goal: Int!
+    affiliates: [AffiliateDownload!]!
+  }
+
   type Query {
     me: User
     fetchMe(token: String!): User
@@ -265,6 +276,7 @@ module.exports = gql`
     getFlaggedVideos: [Video]
     getFlaggedPictures: [Picture]
     getRealUsers: [User]
+    getAffiliateDownloads(reportDate: String): AffiliateLeaderboard!
   }
 
   type GoogleAuth {

--- a/utils/appStoreConnect.js
+++ b/utils/appStoreConnect.js
@@ -1,0 +1,267 @@
+const axios = require("axios");
+const jwt = require("jsonwebtoken");
+const zlib = require("zlib");
+
+const DEFAULT_DELAY_DAYS = Number.isFinite(
+  Number(process.env.APP_STORE_CONNECT_DELAY_DAYS)
+)
+  ? Number(process.env.APP_STORE_CONNECT_DELAY_DAYS)
+  : 2;
+const DOWNLOAD_GOAL = Number.isFinite(Number(process.env.AFFILIATE_DOWNLOAD_GOAL))
+  ? Number(process.env.AFFILIATE_DOWNLOAD_GOAL)
+  : 1000;
+const CACHE_TTL_MINUTES = Number.isFinite(
+  Number(process.env.APP_STORE_CONNECT_CACHE_MINUTES)
+)
+  ? Number(process.env.APP_STORE_CONNECT_CACHE_MINUTES)
+  : 30;
+const REPORT_SUBTYPE =
+  process.env.APP_STORE_CONNECT_AFFILIATE_SUBTYPE || "SIAFFILIATE";
+const SALES_REPORT_URL =
+  process.env.APP_STORE_CONNECT_SALES_URL ||
+  "https://api.appstoreconnect.apple.com/v1/salesReports";
+
+const cache = {
+  key: null,
+  fetchedAt: 0,
+  payload: null,
+};
+
+const getDefaultReportDate = () => {
+  const delay = Number.isFinite(DEFAULT_DELAY_DAYS) ? DEFAULT_DELAY_DAYS : 2;
+  const target = new Date();
+  target.setUTCDate(target.getUTCDate() - delay);
+  return target.toISOString().split("T")[0];
+};
+
+const formatPrivateKey = (privateKey) => {
+  if (!privateKey) {
+    return "";
+  }
+
+  const replaced = privateKey.replace(/\\n/g, "\n");
+
+  if (replaced.includes("BEGIN")) {
+    return replaced;
+  }
+
+  try {
+    const decoded = Buffer.from(replaced, "base64").toString("utf8");
+    if (decoded.includes("BEGIN")) {
+      return decoded;
+    }
+  } catch (error) {
+    // Swallow decoding errors and fall back to the original string.
+  }
+
+  return replaced;
+};
+
+const createJWT = () => {
+  const keyId = process.env.APP_STORE_CONNECT_KEY_ID;
+  const issuerId = process.env.APP_STORE_CONNECT_ISSUER_ID;
+  const privateKey = formatPrivateKey(
+    process.env.APP_STORE_CONNECT_PRIVATE_KEY || ""
+  );
+
+  if (!keyId || !issuerId || !privateKey) {
+    throw new Error(
+      "Missing App Store Connect credentials. Please verify APP_STORE_CONNECT_KEY_ID, APP_STORE_CONNECT_ISSUER_ID, and APP_STORE_CONNECT_PRIVATE_KEY environment variables."
+    );
+  }
+
+  const payload = {
+    iss: issuerId,
+    aud: "appstoreconnect-v1",
+    exp: Math.floor(Date.now() / 1000) + 60 * 5,
+  };
+
+  return jwt.sign(payload, privateKey, {
+    algorithm: "ES256",
+    header: {
+      alg: "ES256",
+      typ: "JWT",
+      kid: keyId,
+    },
+  });
+};
+
+const findColumnIndex = (headers, candidates) => {
+  return candidates.reduce((acc, candidate) => {
+    if (acc !== -1) {
+      return acc;
+    }
+
+    const index = headers.findIndex(
+      (header) => header.trim().toLowerCase() === candidate.toLowerCase()
+    );
+
+    return index === -1 ? acc : index;
+  }, -1);
+};
+
+const parseAffiliateReport = (reportContent) => {
+  if (!reportContent) {
+    return [];
+  }
+
+  const trimmed = reportContent.trim();
+
+  if (!trimmed || /no data/i.test(trimmed)) {
+    return [];
+  }
+
+  const lines = trimmed.split(/\r?\n/).filter(Boolean);
+  if (lines.length <= 1) {
+    return [];
+  }
+
+  const headers = lines[0].split("\t");
+  let affiliateIndex = findColumnIndex(headers, [
+    "affiliate",
+    "affiliate name",
+    "affiliate token",
+    "affiliate_token",
+    "partner",
+    "partner name",
+  ]);
+
+  if (affiliateIndex === -1) {
+    affiliateIndex = findColumnIndex(headers, ["provider", "title", "sku"]);
+  }
+
+  const unitsIndex = findColumnIndex(headers, ["units", "downloads", "quantity"]);
+
+  if (affiliateIndex === -1 || unitsIndex === -1) {
+    throw new Error(
+      "Affiliate or units column could not be located in the App Store Connect report."
+    );
+  }
+
+  const results = new Map();
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const row = lines[i].split("\t");
+    if (row.length <= Math.max(affiliateIndex, unitsIndex)) {
+      continue;
+    }
+
+    const affiliateName = row[affiliateIndex]
+      ? row[affiliateIndex].trim() || "Unknown Affiliate"
+      : "Unknown Affiliate";
+
+    const parsedUnits = parseInt(row[unitsIndex], 10);
+    const units = Number.isFinite(parsedUnits) ? parsedUnits : 0;
+
+    if (!results.has(affiliateName)) {
+      results.set(affiliateName, 0);
+    }
+
+    results.set(affiliateName, results.get(affiliateName) + units);
+  }
+
+  return Array.from(results.entries())
+    .map(([affiliateName, downloads]) => ({ affiliateName, downloads }))
+    .sort((a, b) => b.downloads - a.downloads);
+};
+
+const deserializeReport = (buffer) => {
+  if (!buffer || !buffer.length) {
+    return "";
+  }
+
+  try {
+    return zlib.gunzipSync(buffer).toString("utf8");
+  } catch (error) {
+    return buffer.toString("utf8");
+  }
+};
+
+const minutesToMs = (minutes) => minutes * 60 * 1000;
+
+const fetchAffiliateDownloads = async ({ reportDate } = {}) => {
+  const vendorNumber = process.env.APP_STORE_CONNECT_VENDOR_NUMBER;
+
+  if (!vendorNumber) {
+    throw new Error(
+      "Missing App Store Connect vendor number. Please set APP_STORE_CONNECT_VENDOR_NUMBER."
+    );
+  }
+
+  const resolvedDate = reportDate || getDefaultReportDate();
+  const cacheKey = `${resolvedDate}`;
+  const now = Date.now();
+
+  if (
+    cache.key === cacheKey &&
+    cache.payload &&
+    now - cache.fetchedAt < minutesToMs(CACHE_TTL_MINUTES)
+  ) {
+    return cache.payload;
+  }
+
+  const token = createJWT();
+
+  try {
+    const response = await axios.get(SALES_REPORT_URL, {
+      params: {
+        "filter[reportType]": "SALES",
+        "filter[reportSubType]": REPORT_SUBTYPE,
+        "filter[frequency]": "DAILY",
+        "filter[reportDate]": resolvedDate,
+        "filter[vendorNumber]": vendorNumber,
+      },
+      responseType: "arraybuffer",
+      timeout: 15000,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/a-gzip",
+      },
+    });
+
+    if (response.status === 204) {
+      const payload = {
+        reportDate: resolvedDate,
+        goal: DOWNLOAD_GOAL,
+        affiliates: [],
+      };
+      cache.key = cacheKey;
+      cache.fetchedAt = now;
+      cache.payload = payload;
+      return payload;
+    }
+
+    const reportText = deserializeReport(Buffer.from(response.data));
+    const affiliates = parseAffiliateReport(reportText);
+
+    const payload = {
+      reportDate: resolvedDate,
+      goal: DOWNLOAD_GOAL,
+      affiliates,
+    };
+
+    cache.key = cacheKey;
+    cache.fetchedAt = now;
+    cache.payload = payload;
+
+    return payload;
+  } catch (error) {
+    if (error.response && error.response.status === 404) {
+      return {
+        reportDate: resolvedDate,
+        goal: DOWNLOAD_GOAL,
+        affiliates: [],
+      };
+    }
+
+    const detail =
+      error.response?.data?.errors?.[0]?.detail || error.message || error.toString();
+
+    throw new Error(`Failed to fetch App Store Connect affiliate downloads: ${detail}`);
+  }
+};
+
+module.exports = {
+  fetchAffiliateDownloads,
+  DOWNLOAD_GOAL,
+};


### PR DESCRIPTION
## Summary
- add an App Store Connect helper that generates JWTs, requests affiliate reports, and parses download totals
- expose the new getAffiliateDownloads schema and resolver in GraphQL and surface it via the client query map
- create a /leaderboard route with a React page that fetches affiliate downloads and renders progress bars for each partner

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c836f778cc8324ac390e0cb04f4952